### PR TITLE
added feed to local storage, setup method for invalidating the cache,…

### DIFF
--- a/src/api/api.js
+++ b/src/api/api.js
@@ -1,8 +1,26 @@
 import superagent from 'superagent';
+import { getCache } from '../lib/getCache.js';
 
 export const retrieveFeed = async tones => {
-  let query = tones && tones.length ? `?pref=${tones.join('+')}` : '';
-  let url = `${process.env.REACT_APP_API_URL}feed/${query}`;
-  let res = await superagent.get(url);
-  return res.body;
+
+  let feed = getCache('intellinewz.feed');
+
+  if (feed) { 
+    return tones && tones.length ? feed.feed.filter(article => tones.includes(article.dom_tone.toLowerCase())) : feed.feed;
+  }
+  else {
+    let query = tones && tones.length ? `?pref=${tones.join('+')}` : '';
+    let url = `${process.env.REACT_APP_API_URL}feed/${query}`;
+    let res = await superagent.get(url);
+    
+    /* SETTING TIME OF CACHE FOR VALIDATION PURPOSES */
+    res.body.cacheTime = new Date().getTime();
+    
+    localStorage.setItem('intellinewz.feed', JSON.stringify(res.body));
+    
+    return res.body.feed;
+  }
+
+
+  
 };

--- a/src/components/feed/feed.js
+++ b/src/components/feed/feed.js
@@ -27,19 +27,24 @@ class Feed extends Component {
       this.props.deleteTone(selectedTone);
       let tones = this.props.tones.filter(tone => tone !== selectedTone);
       if (tones.length) { this.retrieveFeed(tones); }
-      else { this.props.deleteFeed(); }
+      else { this.retrieveFeed(); }
       
     }
   }
 
-  retrieveFeed = async tones => {
+  retrieveFeed = async (tones = null) => {
     let feed = await retrieveFeed(tones);
-    this.props.addToFeed(feed.feed);
+    this.props.addToFeed(feed);
   }
 
   render() {
     //detect joy, fear, sadness, anger, analytical, confident and tentative tones
     let tones = ['joy', 'fear', 'sadness', 'anger', 'analytical', 'confident', 'tentative'];
+
+    (this.props.tones && this.props.tones.length) 
+    || (this.props.feed && this.props.feed.length) 
+      ? null : this.retrieveFeed();
+
     return (
       <React.Fragment>
         <section className="tone-links">

--- a/src/lib/getCache.js
+++ b/src/lib/getCache.js
@@ -1,0 +1,17 @@
+export const getCache = key => {
+
+  let payload = JSON.parse(localStorage.getItem(key));
+  
+  if (payload) { 
+    let expired = isExpired(payload);
+    return expired ? null : payload;
+  } else {
+    return null;
+  }
+};
+
+const isExpired = payload => {
+  let currentTime = new Date().getTime();
+  let difference = currentTime - payload.cacheTime;
+  return difference >= 3000 ? true : false;
+};


### PR DESCRIPTION
… changed the home page to default to displaying everything article in feed and then filtering

With this PR: 
- [x] User defaults to seeing all the articles in the feed
- [x] Feed is stored in local storage as a cache
- [x] Method exists to invalidate the cache
- [x] Rather than make API requests for each dom_tone the cache is the filtered with appropriate tones